### PR TITLE
Remove input field shadow and focus highlight

### DIFF
--- a/assets/forms.css
+++ b/assets/forms.css
@@ -1,0 +1,23 @@
+/* Styling adjustments for Stoke Gravity Forms for Elementor fields */
+.sge-gravity-form input,
+.sge-gravity-form select,
+.sge-gravity-form textarea {
+    box-shadow: none;
+}
+
+.sge-gravity-form input:focus,
+.sge-gravity-form select:focus,
+.sge-gravity-form textarea:focus {
+    box-shadow: none;
+    outline: none;
+}
+
+/* Remove system selection highlight when typing */
+.sge-gravity-form input::selection,
+.sge-gravity-form input::-moz-selection,
+.sge-gravity-form select::selection,
+.sge-gravity-form select::-moz-selection,
+.sge-gravity-form textarea::selection,
+.sge-gravity-form textarea::-moz-selection {
+    background: transparent;
+}

--- a/stoke-gf-elementor.php
+++ b/stoke-gf-elementor.php
@@ -96,3 +96,18 @@ add_action(
 		echo "<div class='error is-dismissible' style='padding: 1.25em 0 1.25em 1em;'>$notice</div>"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 );
+/**
+ * Enqueue frontend styles.
+ *
+ * @since 1.0.0
+ */
+function enqueue_frontend_styles() {
+        wp_enqueue_style(
+                'stoke-gf-elementor',
+                plugin_dir_url( __FILE__ ) . 'assets/forms.css',
+                array(),
+                '1.0.0'
+        );
+}
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_frontend_styles' );
+


### PR DESCRIPTION
## Summary
- add CSS to clear form field box shadow and focus/selection highlight
- enqueue custom stylesheet for frontend forms

## Testing
- `php -l stoke-gf-elementor.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bd5e407074832cb43448be1fd4bc44