### PR TITLE
Allow custom styling on Gravity Forms submit buttons

### DIFF
--- a/assets/forms.css
+++ b/assets/forms.css
@@ -1,7 +1,11 @@
 /* Styling adjustments for Stoke Gravity Forms for Elementor fields */
 .sge-gravity-form input,
 .sge-gravity-form select,
-.sge-gravity-form textarea {
+.sge-gravity-form textarea,
+.sge-gravity-form .gform_button,
+.sge-gravity-form .gform_next_button,
+.sge-gravity-form .gform_previous_button,
+.sge-gravity-form .gform_save_link {
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
@@ -14,7 +18,11 @@
 
 .sge-gravity-form input:focus,
 .sge-gravity-form select:focus,
-.sge-gravity-form textarea:focus {
+.sge-gravity-form textarea:focus,
+.sge-gravity-form .gform_button:focus,
+.sge-gravity-form .gform_next_button:focus,
+.sge-gravity-form .gform_previous_button:focus,
+.sge-gravity-form .gform_save_link:focus {
     box-shadow: none !important;
     outline: none !important;
     -webkit-box-shadow: none !important;


### PR DESCRIPTION
## Summary
- clear default appearance for Gravity Forms submit/next/previous buttons so Elementor styles apply

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bd694ef098832c89988fb400b197db