### PR TITLE
Allow individual styling on Gravity Forms buttons

### DIFF
--- a/assets/forms.css
+++ b/assets/forms.css
@@ -1,5 +1,5 @@
 /* Styling adjustments for Stoke Gravity Forms for Elementor fields */
-.sge-gravity-form input,
+.sge-gravity-form input:not([type="checkbox"]):not([type="radio"]),
 .sge-gravity-form select,
 .sge-gravity-form textarea {
     -webkit-appearance: none;
@@ -12,7 +12,7 @@
     box-shadow: none;
 }
 
-.sge-gravity-form input:focus,
+.sge-gravity-form input:not([type="checkbox"]):not([type="radio"]):focus,
 .sge-gravity-form select:focus,
 .sge-gravity-form textarea:focus {
     box-shadow: none !important;
@@ -96,4 +96,45 @@
 .sge-gravity-form textarea::selection,
 .sge-gravity-form textarea::-moz-selection {
     background: transparent;
+}
+
+/* Checkboxes and radios */
+.sge-gravity-form .ginput_container_checkbox input[type="checkbox"],
+.sge-gravity-form .ginput_container_radio input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+}
+
+.sge-gravity-form .ginput_container_checkbox label,
+.sge-gravity-form .ginput_container_radio label {
+    position: relative;
+    display: inline-block;
+    padding-left: 1.5em;
+    cursor: pointer;
+}
+
+.sge-gravity-form .ginput_container_checkbox input[type="checkbox"] + label::before,
+.sge-gravity-form .ginput_container_radio input[type="radio"] + label::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1em;
+    height: 1em;
+    border: 1px solid currentColor;
+    background: transparent;
+}
+
+.sge-gravity-form .ginput_container_checkbox input[type="checkbox"] + label::before {
+    border-radius: 2px;
+}
+
+.sge-gravity-form .ginput_container_radio input[type="radio"] + label::before {
+    border-radius: 50%;
+}
+
+.sge-gravity-form .ginput_container_checkbox input[type="checkbox"]:checked + label::before,
+.sge-gravity-form .ginput_container_radio input[type="radio"]:checked + label::before {
+    background: currentColor;
 }

--- a/assets/forms.css
+++ b/assets/forms.css
@@ -23,6 +23,71 @@
     outline: none;
 }
 
+/* Submit button */
+.sge-gravity-form .gform_button,
+.sge-gravity-form .gform_save_link {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: none !important;
+    outline: none !important;
+    -webkit-box-shadow: none !important;
+    -webkit-tap-highlight-color: transparent;
+    box-shadow: none;
+}
+
+.sge-gravity-form .gform_button:focus,
+.sge-gravity-form .gform_save_link:focus {
+    box-shadow: none !important;
+    outline: none !important;
+    -webkit-box-shadow: none !important;
+    border-color: inherit !important;
+    box-shadow: none;
+    outline: none;
+}
+
+/* Next button */
+.sge-gravity-form .gform_next_button {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: none !important;
+    outline: none !important;
+    -webkit-box-shadow: none !important;
+    -webkit-tap-highlight-color: transparent;
+    box-shadow: none;
+}
+
+.sge-gravity-form .gform_next_button:focus {
+    box-shadow: none !important;
+    outline: none !important;
+    -webkit-box-shadow: none !important;
+    border-color: inherit !important;
+    box-shadow: none;
+    outline: none;
+}
+
+/* Previous button */
+.sge-gravity-form .gform_previous_button {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: none !important;
+    outline: none !important;
+    -webkit-box-shadow: none !important;
+    -webkit-tap-highlight-color: transparent;
+    box-shadow: none;
+}
+
+.sge-gravity-form .gform_previous_button:focus {
+    box-shadow: none !important;
+    outline: none !important;
+    -webkit-box-shadow: none !important;
+    border-color: inherit !important;
+    box-shadow: none;
+    outline: none;
+}
+
 /* Remove system selection highlight when typing */
 .sge-gravity-form input::selection,
 .sge-gravity-form input::-moz-selection,

--- a/includes/Widget.php
+++ b/includes/Widget.php
@@ -148,21 +148,13 @@ class Widget extends Widget_Base {
 
 $textarea = '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gfield .ginput_container textarea';
 
-$checks_radios = implode(
-        ', ',
-        array(
-                '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .ginput_container_checkbox input[type="checkbox"]',
-                '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .ginput_container_radio input[type="radio"]',
-        )
-);
-
 // Pseudo-element selectors using the label for custom checkboxes and radios.
 $checks_radios_before = implode(
-        ', ',
-        array(
-                '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .ginput_container_checkbox input[type="checkbox"] + label::before',
-                '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .ginput_container_radio input[type="radio"] + label::before',
-        )
+       ', ',
+       array(
+               '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .ginput_container_checkbox input[type="checkbox"] + label::before',
+               '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .ginput_container_radio input[type="radio"] + label::before',
+       )
 );
 
 $checks_radios_checked_before = implode(
@@ -703,19 +695,6 @@ $this->end_controls_section();
                         'label' => __( 'Checkboxes & Radios', 'stoke-gf-elementor' ),
                         'tab'   => Controls_Manager::TAB_STYLE,
                         )
-                        );
-
-                        // Remove default appearance and create pseudo elements.
-                        $this->add_control(
-                                'checks_radios_reset_native',
-                                array(
-                                        'type'      => Controls_Manager::HIDDEN,
-                                        'selectors' => array(
-                                                $checks_radios       => 'opacity: 0; position: absolute;',
-                                                $checks_radios_labels => 'position: relative; display: inline-block; padding-left: 1.5em;',
-                                                $checks_radios_before => 'content: ""; position: absolute; left: 0; top: 50%; transform: translateY(-50%); width: 1em; height: 1em;',
-                                        ),
-                                )
                         );
 
                         // Accent color control for check mark / selection.

--- a/includes/Widget.php
+++ b/includes/Widget.php
@@ -220,15 +220,17 @@ $sub_labels = implode(
                         )
                 );
 
-                $buttons = implode(
+                $submit_button = implode(
                         ', ',
                         array(
                                 '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gform_button',
-                                '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gform_next_button',
-                                '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gform_previous_button',
                                 '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gform_save_link',
                         )
                 );
+
+                $next_button = '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gform_next_button';
+
+                $previous_button = '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gform_previous_button';
 
 
                $this->start_controls_section(
@@ -937,9 +939,9 @@ $textarea => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LE
 $this->end_controls_section();
 
                 $this->start_controls_section(
-                        'section_buttons',
+                        'section_submit_button',
                         array(
-                                'label' => __( 'Buttons', 'stoke-gf-elementor' ),
+                                'label' => __( 'Submit Button', 'stoke-gf-elementor' ),
                                 'tab'   => Controls_Manager::TAB_STYLE,
                         )
                 );
@@ -947,29 +949,29 @@ $this->end_controls_section();
                 $this->add_group_control(
                         Group_Control_Typography::get_type(),
                         array(
-                                'name'     => 'buttons_typography',
-                                'selector' => $buttons,
+                                'name'     => 'submit_button_typography',
+                                'selector' => $submit_button,
                         )
                 );
 
                 $this->add_control(
-                        'buttons_text_color',
+                        'submit_button_text_color',
                         array(
                                 'label'     => __( 'Text Color', 'stoke-gf-elementor' ),
                                 'type'      => Controls_Manager::COLOR,
                                 'selectors' => array(
-                                        $buttons => 'color: {{VALUE}};',
+                                        $submit_button => 'color: {{VALUE}};',
                                 ),
                         )
                 );
 
                 $this->add_control(
-                        'buttons_hover_text_color',
+                        'submit_button_hover_text_color',
                         array(
                                 'label'     => __( 'Hover Text Color', 'stoke-gf-elementor' ),
                                 'type'      => Controls_Manager::COLOR,
                                 'selectors' => array(
-                                        str_replace( ', ', ':hover, ', $buttons ) . ':hover' => 'color: {{VALUE}};',
+                                        str_replace( ', ', ':hover, ', $submit_button ) . ':hover' => 'color: {{VALUE}};',
                                 ),
                         )
                 );
@@ -977,48 +979,226 @@ $this->end_controls_section();
                 $this->add_group_control(
                         Group_Control_Background::get_type(),
                         array(
-                                'name'     => 'buttons_background',
-                                'selector' => $buttons,
+                                'name'     => 'submit_button_background',
+                                'selector' => $submit_button,
                         )
                 );
 
                 $this->add_group_control(
                         Group_Control_Background::get_type(),
                         array(
-                                'name'     => 'buttons_hover_background',
+                                'name'     => 'submit_button_hover_background',
                                 'label'    => __( 'Hover Background', 'stoke-gf-elementor' ),
-                                'selector' => str_replace( ', ', ':hover, ', $buttons ) . ':hover',
+                                'selector' => str_replace( ', ', ':hover, ', $submit_button ) . ':hover',
                         )
                 );
 
                 $this->add_group_control(
                         Group_Control_Border::get_type(),
                         array(
-                                'name'     => 'buttons_border',
-                                'selector' => $buttons,
+                                'name'     => 'submit_button_border',
+                                'selector' => $submit_button,
                         )
                 );
 
                $this->add_responsive_control(
-                       'buttons_border_radius',
+                       'submit_button_border_radius',
                        array(
                                'label'      => __( 'Border Radius', 'stoke-gf-elementor' ),
                                'type'       => Controls_Manager::DIMENSIONS,
                                'size_units' => array( 'px', 'em', '%' ),
                                'selectors'  => array(
-                                       $buttons => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                                       $submit_button => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
                                ),
                        )
                );
 
                 $this->add_responsive_control(
-                        'buttons_padding',
+                        'submit_button_padding',
                         array(
                                 'label'      => __( 'Padding', 'stoke-gf-elementor' ),
                                 'type'       => Controls_Manager::DIMENSIONS,
                                 'size_units' => array( 'px', 'em', '%' ),
                                 'selectors'  => array(
-                                        $buttons => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                                        $submit_button => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                                ),
+                        )
+                );
+
+                $this->end_controls_section();
+
+                $this->start_controls_section(
+                        'section_next_button',
+                        array(
+                                'label' => __( 'Next Button', 'stoke-gf-elementor' ),
+                                'tab'   => Controls_Manager::TAB_STYLE,
+                        )
+                );
+
+                $this->add_group_control(
+                        Group_Control_Typography::get_type(),
+                        array(
+                                'name'     => 'next_button_typography',
+                                'selector' => $next_button,
+                        )
+                );
+
+                $this->add_control(
+                        'next_button_text_color',
+                        array(
+                                'label'     => __( 'Text Color', 'stoke-gf-elementor' ),
+                                'type'      => Controls_Manager::COLOR,
+                                'selectors' => array(
+                                        $next_button => 'color: {{VALUE}};',
+                                ),
+                        )
+                );
+
+                $this->add_control(
+                        'next_button_hover_text_color',
+                        array(
+                                'label'     => __( 'Hover Text Color', 'stoke-gf-elementor' ),
+                                'type'      => Controls_Manager::COLOR,
+                                'selectors' => array(
+                                        $next_button . ':hover' => 'color: {{VALUE}};',
+                                ),
+                        )
+                );
+
+                $this->add_group_control(
+                        Group_Control_Background::get_type(),
+                        array(
+                                'name'     => 'next_button_background',
+                                'selector' => $next_button,
+                        )
+                );
+
+                $this->add_group_control(
+                        Group_Control_Background::get_type(),
+                        array(
+                                'name'     => 'next_button_hover_background',
+                                'label'    => __( 'Hover Background', 'stoke-gf-elementor' ),
+                                'selector' => $next_button . ':hover',
+                        )
+                );
+
+                $this->add_group_control(
+                        Group_Control_Border::get_type(),
+                        array(
+                                'name'     => 'next_button_border',
+                                'selector' => $next_button,
+                        )
+                );
+
+               $this->add_responsive_control(
+                       'next_button_border_radius',
+                       array(
+                               'label'      => __( 'Border Radius', 'stoke-gf-elementor' ),
+                               'type'       => Controls_Manager::DIMENSIONS,
+                               'size_units' => array( 'px', 'em', '%' ),
+                               'selectors'  => array(
+                                       $next_button => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                               ),
+                       )
+               );
+
+                $this->add_responsive_control(
+                        'next_button_padding',
+                        array(
+                                'label'      => __( 'Padding', 'stoke-gf-elementor' ),
+                                'type'       => Controls_Manager::DIMENSIONS,
+                                'size_units' => array( 'px', 'em', '%' ),
+                                'selectors'  => array(
+                                        $next_button => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                                ),
+                        )
+                );
+
+                $this->end_controls_section();
+
+                $this->start_controls_section(
+                        'section_previous_button',
+                        array(
+                                'label' => __( 'Previous Button', 'stoke-gf-elementor' ),
+                                'tab'   => Controls_Manager::TAB_STYLE,
+                        )
+                );
+
+                $this->add_group_control(
+                        Group_Control_Typography::get_type(),
+                        array(
+                                'name'     => 'previous_button_typography',
+                                'selector' => $previous_button,
+                        )
+                );
+
+                $this->add_control(
+                        'previous_button_text_color',
+                        array(
+                                'label'     => __( 'Text Color', 'stoke-gf-elementor' ),
+                                'type'      => Controls_Manager::COLOR,
+                                'selectors' => array(
+                                        $previous_button => 'color: {{VALUE}};',
+                                ),
+                        )
+                );
+
+                $this->add_control(
+                        'previous_button_hover_text_color',
+                        array(
+                                'label'     => __( 'Hover Text Color', 'stoke-gf-elementor' ),
+                                'type'      => Controls_Manager::COLOR,
+                                'selectors' => array(
+                                        $previous_button . ':hover' => 'color: {{VALUE}};',
+                                ),
+                        )
+                );
+
+                $this->add_group_control(
+                        Group_Control_Background::get_type(),
+                        array(
+                                'name'     => 'previous_button_background',
+                                'selector' => $previous_button,
+                        )
+                );
+
+                $this->add_group_control(
+                        Group_Control_Background::get_type(),
+                        array(
+                                'name'     => 'previous_button_hover_background',
+                                'label'    => __( 'Hover Background', 'stoke-gf-elementor' ),
+                                'selector' => $previous_button . ':hover',
+                        )
+                );
+
+                $this->add_group_control(
+                        Group_Control_Border::get_type(),
+                        array(
+                                'name'     => 'previous_button_border',
+                                'selector' => $previous_button,
+                        )
+                );
+
+               $this->add_responsive_control(
+                       'previous_button_border_radius',
+                       array(
+                               'label'      => __( 'Border Radius', 'stoke-gf-elementor' ),
+                               'type'       => Controls_Manager::DIMENSIONS,
+                               'size_units' => array( 'px', 'em', '%' ),
+                               'selectors'  => array(
+                                       $previous_button => 'border-radius: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                               ),
+                       )
+               );
+
+                $this->add_responsive_control(
+                        'previous_button_padding',
+                        array(
+                                'label'      => __( 'Padding', 'stoke-gf-elementor' ),
+                                'type'       => Controls_Manager::DIMENSIONS,
+                                'size_units' => array( 'px', 'em', '%' ),
+                                'selectors'  => array(
+                                        $previous_button => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
                                 ),
                         )
                 );


### PR DESCRIPTION
## Summary
- provide separate Elementor styling controls for submit, next, and previous Gravity Forms buttons
- normalize default appearance for each button to allow custom styles

## Testing
- `php -l includes/Widget.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bd694ef098832c89988fb400b197db