### PR TITLE
feat: style field descriptions

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- Typography and color controls for field descriptions
+
 ## [1.0.1] - 2025-09-07
 ### Fixed
 - Checkbox alignment issue on the left margin

--- a/includes/Widget.php
+++ b/includes/Widget.php
@@ -609,6 +609,34 @@ $sub_labels = implode(
                        )
                );
 
+               $this->add_control(
+                       'field_description_heading',
+                       array(
+                               'label'     => __( 'Field Descriptions', 'stoke-gf-elementor' ),
+                               'type'      => Controls_Manager::HEADING,
+                               'separator' => 'before',
+                       )
+               );
+
+               $this->add_group_control(
+                       Group_Control_Typography::get_type(),
+                       array(
+                               'name'     => 'field_description_typography',
+                               'selector' => '{{WRAPPER}} .sge-gravity-form .gfield_description',
+                       )
+               );
+
+               $this->add_control(
+                       'field_description_color',
+                       array(
+                               'label'     => __( 'Text Color', 'stoke-gf-elementor' ),
+                               'type'      => Controls_Manager::COLOR,
+                               'selectors' => array(
+                                       '{{WRAPPER}} .sge-gravity-form .gfield_description' => 'color: {{VALUE}};',
+                               ),
+                       )
+               );
+
                $this->end_controls_section();
 
                $this->start_controls_section(


### PR DESCRIPTION
## Summary
- allow typography and color controls for field descriptions
- document field description styling support

## Testing
- `php -l includes/Widget.php`


------
https://chatgpt.com/codex/tasks/task_b_68be4aa60708832c95a1254445e997c7