### PR TITLE
Add styling controls and spacing for Gravity Forms elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tags: gravity forms, elementor, widget, form builder
 Requires at least: 5.0
 Tested up to: 6.7
 Requires PHP: 7.2
-Stable tag: 1.0.0
+Stable tag: 1.0.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/assets/forms.css
+++ b/assets/forms.css
@@ -207,3 +207,41 @@
 .sge-gravity-form .ginput_container_consent input[type="checkbox"]:checked + label::before {
     background: currentColor;
 }
+
+/* Section headings */
+.sge-gravity-form .gsection_title,
+.sge-gravity-form .gsection_description {
+    color: inherit;
+    font: inherit;
+}
+
+/* HTML fields */
+.sge-gravity-form .gfield_html,
+.sge-gravity-form .gfield_html * {
+    color: inherit;
+    font: inherit;
+}
+
+/* List field column headings */
+.sge-gravity-form .gfield_list thead th {
+    color: inherit;
+    font: inherit;
+}
+
+/* Side-by-side textareas spacing */
+.sge-gravity-form .ginput_container_textarea {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 50px;
+}
+
+.sge-gravity-form .ginput_container_textarea textarea {
+    flex: 1;
+}
+
+/* Gravity Wiz Nested Forms typography */
+.sge-gravity-form .gpnf-nested-form,
+.sge-gravity-form .gpnf-nested-form * {
+    color: inherit;
+    font: inherit;
+}

--- a/changelog
+++ b/changelog
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## [1.0.3] - 2025-09-09
+### Added
+- Color and typography controls for HTML fields, section headings, and list field column headings
+- 50px spacing between adjacent textareas
+- Default typography for Gravity Wiz Nested Forms elements
+
 ## [1.0.2] - 2025-09-08
 ### Added
 - Typography and color controls for field descriptions

--- a/includes/Widget.php
+++ b/includes/Widget.php
@@ -547,7 +547,7 @@ $sub_labels = implode(
                        Group_Control_Typography::get_type(),
                        array(
                                'name'     => 'label_typography',
-                               'selector' => '{{WRAPPER}} .sge-gravity-form .gfield_label',
+                               'selector' => '{{WRAPPER}} .sge-gravity-form .gfield_label, {{WRAPPER}} .sge-gravity-form .gpnf-field-label',
                        )
                );
 
@@ -557,7 +557,7 @@ $sub_labels = implode(
                                'label'     => __( 'Text Color', 'stoke-gf-elementor' ),
                                'type'      => Controls_Manager::COLOR,
                                'selectors' => array(
-                                       '{{WRAPPER}} .sge-gravity-form .gfield_label' => 'color: {{VALUE}};',
+                                       '{{WRAPPER}} .sge-gravity-form .gfield_label, {{WRAPPER}} .sge-gravity-form .gpnf-field-label' => 'color: {{VALUE}};',
                                ),
                        )
                );
@@ -639,6 +639,113 @@ $sub_labels = implode(
                                'type'      => Controls_Manager::COLOR,
                                'selectors' => array(
                                        '{{WRAPPER}} .sge-gravity-form .gfield_description' => 'color: {{VALUE}};',
+                               ),
+                       )
+               );
+
+               $this->end_controls_section();
+
+               $this->start_controls_section(
+                       'section_section_headings',
+                       array(
+                               'label' => __( 'Section Headings', 'stoke-gf-elementor' ),
+                               'tab'   => Controls_Manager::TAB_STYLE,
+                       )
+               );
+
+               $this->add_group_control(
+                       Group_Control_Typography::get_type(),
+                       array(
+                               'name'     => 'section_heading_typography',
+                               'selector' => '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gsection_title',
+                       )
+               );
+
+               $this->add_control(
+                       'section_heading_color',
+                       array(
+                               'label'     => __( 'Heading Color', 'stoke-gf-elementor' ),
+                               'type'      => Controls_Manager::COLOR,
+                               'selectors' => array(
+                                       '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gsection_title' => 'color: {{VALUE}};',
+                               ),
+                       )
+               );
+
+               $this->add_group_control(
+                       Group_Control_Typography::get_type(),
+                       array(
+                               'name'     => 'section_description_typography',
+                               'label'    => __( 'Description Typography', 'stoke-gf-elementor' ),
+                               'selector' => '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gsection_description',
+                       )
+               );
+
+               $this->add_control(
+                       'section_description_color',
+                       array(
+                               'label'     => __( 'Description Color', 'stoke-gf-elementor' ),
+                               'type'      => Controls_Manager::COLOR,
+                               'selectors' => array(
+                                       '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gsection_description' => 'color: {{VALUE}};',
+                               ),
+                       )
+               );
+
+               $this->end_controls_section();
+
+               $this->start_controls_section(
+                       'section_html_fields',
+                       array(
+                               'label' => __( 'HTML Fields', 'stoke-gf-elementor' ),
+                               'tab'   => Controls_Manager::TAB_STYLE,
+                       )
+               );
+
+               $this->add_group_control(
+                       Group_Control_Typography::get_type(),
+                       array(
+                               'name'     => 'html_field_typography',
+                               'selector' => '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gfield_html',
+                       )
+               );
+
+               $this->add_control(
+                       'html_field_color',
+                       array(
+                               'label'     => __( 'Text Color', 'stoke-gf-elementor' ),
+                               'type'      => Controls_Manager::COLOR,
+                               'selectors' => array(
+                                       '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gfield_html' => 'color: {{VALUE}};',
+                               ),
+                       )
+               );
+
+               $this->end_controls_section();
+
+               $this->start_controls_section(
+                       'section_list_field_headings',
+                       array(
+                               'label' => __( 'List Field Column Headings', 'stoke-gf-elementor' ),
+                               'tab'   => Controls_Manager::TAB_STYLE,
+                       )
+               );
+
+               $this->add_group_control(
+                       Group_Control_Typography::get_type(),
+                       array(
+                               'name'     => 'list_field_headings_typography',
+                               'selector' => '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gfield_list thead th',
+                       )
+               );
+
+               $this->add_control(
+                       'list_field_headings_color',
+                       array(
+                               'label'     => __( 'Text Color', 'stoke-gf-elementor' ),
+                               'type'      => Controls_Manager::COLOR,
+                               'selectors' => array(
+                                       '{{WRAPPER}} .' . self::ELEMENT_KEY . ' .gfield_list thead th' => 'color: {{VALUE}};',
                                ),
                        )
                );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gravity forms, elementor, widget, form builder
 Requires at least: 5.0
 Tested up to: 6.7
 Requires PHP: 7.2
-Stable tag: 1.0.1
+Stable tag: 1.0.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/stoke-gf-elementor.php
+++ b/stoke-gf-elementor.php
@@ -3,7 +3,7 @@
  * Plugin Name:         Stoke Gravity Forms for Elementor
  * Plugin URI:          https://stokedesign.co/sandbox
  * Description:         Allows Gravity Forms to easily be inserted and styled in Elementor.
- * Version:             1.0.2
+ * Version:             1.0.3
  * Author:              Stoke Design Co
  * Author URI:          https://stokedesign.co/
  * Text Domain:         stoke-gf-elementor


### PR DESCRIPTION
## Summary
- add typography and color styling for HTML fields, section headings, and list column headings
- enforce 50px spacing between side-by-side textareas and inherit fonts for Nested Forms
- bump plugin version and update changelog

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l stoke-gf-elementor.php`
- `php -l includes/Widget.php`


------
https://chatgpt.com/codex/tasks/task_b_68c012b104d0832c8d9b2b8145318567